### PR TITLE
Fix HTTP parts

### DIFF
--- a/discouple/http.py
+++ b/discouple/http.py
@@ -169,15 +169,16 @@ class RedisRateLimitHandler(BaseRateLimitHandler):
 
 
 async def json_or_text(response):
-    text = await response.text(encoding="utf-8")
     try:
         if response.headers["content-type"] == "application/json":
-            return orjson.loads(text)
+            # orjson prefers bytes
+            body = await response.read()
+            return orjson.loads(body)
     except KeyError:
         # Thanks Cloudflare
         pass
 
-    return text
+    return await response.text(encoding="utf-8")
 
 
 class HTTPClient:


### PR DESCRIPTION
This fixes:
- The Redis ratelimiter: Results are bytes and need to be decoded to be used with strings
- `create_message`: klass was not implemented, it now properly works and returns a Message object. If no klass is set, it returns JSON

It also further improves speed by using the bytes body to parse JSON, as orjson will perform even better and consume less memory with bytes.

Working example (with Redis ratelimit handler):

```py
@client.listener
async def on_message_create(msg):
    if msg.content.startswith("!ping"):
        msg = await client.http.create_message(msg.channel_id, "top kek")
        assert msg.content == "top kek"
```

TODO: When running into the ratelimit, I either get this or it does not queue them at all. Can't figure where it's from right now. When it is not queuing, the tasks are pending when stopping it minutes later
```
/usr/local/lib/python3.9/asyncio/events.py:80: RuntimeWarning: coroutine 'Queue.put' was never awaited
  self._context.run(self._callback, *self._args)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```